### PR TITLE
Remove font-awesome.css import from the landing page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
   <head>
     <title>eLife Lens</title>
     <link href='//fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
-    <link href='dist/styles/font-awesome.css' rel='stylesheet' type='text/css'/>
     <link href='dist/lens.css' rel='stylesheet' type='text/css'/>
     <style type='text/css'>
     .logo


### PR DESCRIPTION
There is no longer a `dist/font-awesome.css` file to import anymore.